### PR TITLE
Remove Unneeded Component Rendering And API Calls

### DIFF
--- a/src/components/CourseSelectionPage/CoursePlan.vue
+++ b/src/components/CourseSelectionPage/CoursePlan.vue
@@ -42,11 +42,7 @@
    import { mapGetters, mapMutations, mapActions } from "vuex";
    import RequirementOptionsModal from '../Modals/RequirementOptionsModal'
    import AddCourseCard from "../Cards/AddCourseCard"
-   import TrieSearch from 'trie-search';
-   import axios from 'axios';
-   import { CourseInfo } from '../../models/courseInfoModel';
    import isMobile from 'ismobilejs';
-   import { backend_api } from '../../backendAPI';
    
    export default {
      name: "CoursePlan",
@@ -56,39 +52,16 @@
        RequirementOptionsModal,
        AddCourseCard
      },
+     props: {
+       allCourses: Object,
+     },
      data() {
        return {
          isDisabled: false,
          termHovered: -1,
-         allCourses: new TrieSearch(['course_code', 'course_number'], {
-           idFieldOrFunction: function(course) {
-             return course.course_id + course.course_code;
-           }
-         }),
        };
      },
-     mounted() {
-       axios.get(backend_api + "/api/course-info/filter", {
-         params: {
-           start: 0,
-           end: 1000,
-           code: "none",
-         }
-       })
-       .then(response => {
-         response.data.sort((course1, course2) => {
-           if (course1.course_code < course2.course_code) return -1;
-           else if (course1.course_code > course2.course_code) 1;
-           else return 0;
-         });
-         this.allCourses.addAll(response.data.map(course => {
-           return new CourseInfo(course)
-         }));
-       })
-       .catch(error => { console.error(error) })
-     },
      methods: {
-       
        ...mapMutations(["addTermToTable", "deleteTermFromTable", "addCourseRequirement",
          "validateCourses", "decrementRequirementID", "updateCacheTime", "sortRequirements"]),
        ...mapActions(["updateChecklist"]),

--- a/src/store/modules/courseSelection.js
+++ b/src/store/modules/courseSelection.js
@@ -215,7 +215,6 @@ function ParseRequirementsForChecklist(requirements, selectedCourses, programInf
                 } else if (course.split(" ")[0] === "NON-MATH") {
                     courseSearchParams = nonMathCourses;
                 }
-                let possibleMatches = [];
                 for (let searchParam of courseSearchParams) {
                     possibleMatches = possibleMatches.concat(selectedCourses.get([searchParam,
                         course.split(" ")[1][0]], TrieSearch.UNION_REDUCER))

--- a/src/store/modules/courses.js
+++ b/src/store/modules/courses.js
@@ -8,15 +8,15 @@ const state = {
     minorRequirements: [],
     specRequirements:  [],
 
-    //this caches all of the stuff and the courses that are currently on the table and on the 
-    courseCache: {}
+    // This maps the course_codes_raw of a req to the course information of courses which satisfy the req
+    courseSatisfactionCache: {}
 };
 
 const getters = {
     majorRequirements: (state) => state.majorRequirements,
     minorRequirements: (state) => state.minorRequirements,
     specRequirements: (state) => state.specRequirements,
-    courseCache: (state) => state.courseCache
+    courseSatisfactionCache: (state) => state.courseSatisfactionCache
 };
 
 
@@ -140,6 +140,9 @@ const actions = {
 };
 
 const mutations = {
+    setCacheItem: (state, { course_codes_raw, satisfyingCourses }) => {
+        state.courseSatisfactionCache[course_codes_raw] = satisfyingCourses;
+    },
     addCourseRequirement: (state, requirement) => {
         if (requirement.major.length) {
             let major = state.majorRequirements.find(req => {

--- a/src/views/CourseSelectionPage.vue
+++ b/src/views/CourseSelectionPage.vue
@@ -125,7 +125,7 @@ export default {
         }
     },
     created() {
-        axios.get(backend_api + "/api/course-info/filter", {
+        axios.get(backend_api + "/course-info/filter", {
             params: {
                 start: 0,
                 end: 1000,


### PR DESCRIPTION
This PR Has 3 main changes:
- Move the fetching of the list of all courses (used by the "add course" buttons) one component layer up to reduce recalling this API on component rerenders
- Adds a cache that stores the list of CourseInfo's that satisfy a given course_codes_raw. This way we only have to make this API call once per session. The cache is in vuex and is not persisted between sessions, there is simply too much data to store on localStorage which caps at 5MB. That said, this change will bring significant API cost reductions.
- Made the Checklist and Plan tabs never derender, instead, they hide themselves when not selected. This means we don't need to rerender the entire page when a user changes tabs.

Not only should these changes reduce the number of API calls, but you should notice that certain actions on the site happen much faster and provide a smoother experience overall (try loading the plan with a bunch of heavy reqs like non-math and switching tabs, compare that to the live site).