### PR TITLE
Resolve Program Selection Inconsistencies

### DIFF
--- a/src/components/ProgramChecklistPage/AdditionalNoteSection.vue
+++ b/src/components/ProgramChecklistPage/AdditionalNoteSection.vue
@@ -44,10 +44,10 @@ export default {
         program: String
     },
     computed: {
-       ...mapGetters(["majorRequirements"]),
-       getLinkToUnderGradCalender: function() {	
-           return this.majorRequirements[0].info.link
-           }
+        ...mapGetters(["majorRequirements"]),
+        getLinkToUnderGradCalender: function() {
+            return this.majorRequirements[0] && this.majorRequirements[0].info.link;
+        }
     }
 }
 </script>


### PR DESCRIPTION
Make program selection more clear
- Fixed bug where switching your major wouldnt clear the minor/options from the modal but the minors and options would not actually be added to their degree upon confirmation
- Made it so that whenever a user selects a new major, all selected minors/options are cleared and a new list of minors and options is loaded for the new major. So no invalid degrees should be possible anymore
