### PR TITLE
Setup https for parallel env

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -43,7 +43,7 @@ http {
     return 301 https://$host$request_uri;
   }
 
-   server {
+  server {
      listen 443 ssl;
      server_name _;
     
@@ -64,5 +64,5 @@ http {
      location = /50x.html {
        root   /usr/share/nginx/html;
      }
-   }
+  }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -39,27 +39,30 @@ http {
       root   /usr/share/nginx/html;
     }
 
-    # Redirect everything to https version (this doesn't work wrror_page worked at last)
-    #return 301 https://$host$request_uri;
+    Redirect everything to https version (this doesn't work wrror_page worked at last)
+    return 301 https://$host$request_uri;
   }
 
-  # server {
-  #   listen 443 ssl;
-  #   server_name uwpath.com www.uwpath.com;
+   server {
+     listen 443 ssl;
+     server_name _;
+    
+     ssl_certificate /etc/secrets/tls.crt;
+     ssl_certificate_key /etc/secrets/tls.key;
 
-  #   location / {
-  #     root   /app;
-  #     index  index.html;
-  #     try_files $uri $uri/ /index.html;
-  #   }
-  #   location /api {
-  #     proxy_pass http://backend;
-  #   }
+     location / {
+       root   /app;
+       index  index.html;
+       try_files $uri $uri/ /index.html;
+     }
+     location /api {
+       proxy_pass http://backend;
+     }
 
-  #   error_page 497 https://$host$request_uri;
+     error_page 497 https://$host$request_uri;
 
-  #   location = /50x.html {
-  #     root   /usr/share/nginx/html;
-  #   }
-  # }
+     location = /50x.html {
+       root   /usr/share/nginx/html;
+     }
+   }
 }


### PR DESCRIPTION
Added HTTPS to the http://parallel.uwpath.com/, might need to roll back to previous version if it does not work.